### PR TITLE
Support portal launch-token entry for reports

### DIFF
--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,5 +1,3 @@
-import os
-
 import httpx
 from fastapi import Request, HTTPException, status
 
@@ -29,7 +27,7 @@ def _verify_token_value(token: str) -> dict:
     return json_response
 
 
-async def verify_token(request: Request) -> bool:
+async def verify_token(request: Request) -> str:
     auth_header = request.headers.get("Authorization")
     bearer_prefix = "Bearer "
 

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,12 +1,39 @@
+import os
+
 import httpx
 from fastapi import Request, HTTPException, status
 
-# Portal Backend URL
-VERIFICATION_URL = "https://b93ddkdz0g.execute-api.ap-south-1.amazonaws.com/auth/verify"
+PORTAL_BACKEND_BASE_URL = (
+    os.getenv("AF_PORTAL_BACKEND_URL")
+    or os.getenv("PORTAL_BACKEND_URL")
+    or "https://b93ddkdz0g.execute-api.ap-south-1.amazonaws.com"
+).rstrip("/")
+VERIFICATION_URL = f"{PORTAL_BACKEND_BASE_URL}/auth/verify"
+
+
+def _verify_token_value(token: str) -> dict:
+    headers = {"Authorization": f"Bearer {token}"}
+    response = httpx.get(VERIFICATION_URL, headers=headers, timeout=10)
+
+    if response.status_code != 200:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    json_response = response.json()
+    if "id" not in json_response:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token payload",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return json_response
 
 
 async def verify_token(request: Request) -> bool:
-    # This function will be used to verify the bearer token
     auth_header = request.headers.get("Authorization")
     bearer_prefix = "Bearer "
 
@@ -18,19 +45,22 @@ async def verify_token(request: Request) -> bool:
         )
 
     token = auth_header[len(bearer_prefix) :]
-    headers = {"Authorization": f"Bearer {token}"}
-    print(VERIFICATION_URL)
-    print(token)
-    async with httpx.AsyncClient() as client:
-        response = await client.get(VERIFICATION_URL, headers=headers)
+    _verify_token_value(token)
+    return token
 
-    if response.status_code == 200:
-        json_response = response.json()
-        if "id" in json_response:
-            return token
 
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Invalid token",
-        headers={"WWW-Authenticate": "Bearer"},
-    )
+def verify_launch_token(token: str, expected_audience: str = "report") -> dict:
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing launch token")
+
+    payload = _verify_token_value(token)
+    token_data = payload.get("data", {})
+
+    if token_data.get("session_mode") != "launch":
+        raise HTTPException(status_code=401, detail="Invalid launch token")
+
+    token_audience = token_data.get("aud")
+    if expected_audience and token_audience != expected_audience:
+        raise HTTPException(status_code=401, detail="Invalid launch token audience")
+
+    return payload

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -3,11 +3,7 @@ import os
 import httpx
 from fastapi import Request, HTTPException, status
 
-PORTAL_BACKEND_BASE_URL = (
-    os.getenv("AF_PORTAL_BACKEND_URL")
-    or os.getenv("PORTAL_BACKEND_URL")
-    or "https://b93ddkdz0g.execute-api.ap-south-1.amazonaws.com"
-).rstrip("/")
+PORTAL_BACKEND_BASE_URL = "https://b93ddkdz0g.execute-api.ap-south-1.amazonaws.com"
 VERIFICATION_URL = f"{PORTAL_BACKEND_BASE_URL}/auth/verify"
 
 

--- a/app/routers/form_responses.py
+++ b/app/routers/form_responses.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, HTTPException
 from fastapi.templating import Jinja2Templates
 from typing import Optional
 import asyncio

--- a/app/routers/form_responses.py
+++ b/app/routers/form_responses.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Request, HTTPException
+from fastapi.responses import RedirectResponse
 from fastapi.templating import Jinja2Templates
 from typing import Optional
 import asyncio
@@ -6,6 +7,8 @@ from auth import verify_launch_token
 from db.form_responses_db import FormResponsesDB
 from utils.pdf_converter import convert_template_to_pdf
 from utils.llm_summary import generate_theme_summary
+
+REPORT_LAUNCH_COOKIE_MAX_AGE = 15 * 60
 
 
 class FormResponsesRouter:
@@ -36,15 +39,95 @@ class FormResponsesRouter:
 
             return str(canonical_user_id)
 
+        def _get_launch_cookie_name(prefix: str, session_id: str) -> str:
+            safe_session_id = "".join(
+                char if char.isalnum() else "_" for char in session_id
+            )
+            return f"{prefix}_{safe_session_id}"
+
+        def _set_launch_cookie(response, request: Request, cookie_name: str, token: str, path: str):
+            response.set_cookie(
+                key=cookie_name,
+                value=token,
+                max_age=REPORT_LAUNCH_COOKIE_MAX_AGE,
+                httponly=True,
+                secure=request.url.scheme == "https",
+                samesite="lax",
+                path=path,
+            )
+
+        def _clean_query_string(request: Request) -> str:
+            params = [
+                (key, value)
+                for key, value in request.query_params.multi_items()
+                if key != "launchToken"
+            ]
+            if not params:
+                return ""
+
+            from urllib.parse import urlencode
+
+            return urlencode(params, doseq=True)
+
+        def _redirect_with_launch_cookie(
+            request: Request,
+            session_id: str,
+            launch_token: str,
+            cookie_prefix: str,
+            clean_path: str,
+        ) -> RedirectResponse:
+            verify_launch_token(launch_token, expected_audience="report")
+            redirect_url = clean_path
+            query_string = _clean_query_string(request)
+            if query_string:
+                redirect_url = f"{redirect_url}?{query_string}"
+
+            response = RedirectResponse(url=redirect_url, status_code=302)
+            cookie_name = _get_launch_cookie_name(cookie_prefix, session_id)
+            _set_launch_cookie(response, request, cookie_name, launch_token, clean_path)
+            return response
+
+        def _get_report_launch_token(
+            request: Request,
+            session_id: str,
+            launch_token: Optional[str],
+            cookie_prefix: str,
+        ) -> str:
+            if launch_token:
+                return launch_token
+
+            cookie_name = _get_launch_cookie_name(cookie_prefix, session_id)
+            token = request.cookies.get(cookie_name)
+            if not token:
+                raise HTTPException(status_code=401, detail="Missing launch token")
+            return token
+
         @api_router.get("/form_responses/{session_id}")
         async def get_form_responses_with_token(
             request: Request,
             session_id: str,
-            launchToken: str,
+            launchToken: Optional[str] = None,
             format: Optional[str] = None,
             debug: bool = False,
         ):
-            resolved_user_id = _resolve_report_user_id(None, launchToken)
+            if launchToken:
+                return _redirect_with_launch_cookie(
+                    request=request,
+                    session_id=session_id,
+                    launch_token=launchToken,
+                    cookie_prefix="form_responses_launch",
+                    clean_path=f"/reports/form_responses/{session_id}",
+                )
+
+            resolved_user_id = _resolve_report_user_id(
+                None,
+                _get_report_launch_token(
+                    request=request,
+                    session_id=session_id,
+                    launch_token=launchToken,
+                    cookie_prefix="form_responses_launch",
+                ),
+            )
             return await get_form_responses(
                 request=request,
                 session_id=session_id,

--- a/app/routers/form_responses.py
+++ b/app/routers/form_responses.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Request, HTTPException
 from fastapi.templating import Jinja2Templates
 from typing import Optional
 import asyncio
+from auth import verify_launch_token
 from db.form_responses_db import FormResponsesDB
 from utils.pdf_converter import convert_template_to_pdf
 from utils.llm_summary import generate_theme_summary
@@ -19,6 +20,38 @@ class FormResponsesRouter:
     @property
     def router(self):
         api_router = APIRouter(prefix="/reports", tags=["form_responses"])
+
+        def _resolve_report_user_id(
+            user_id: Optional[str], launch_token: Optional[str]
+        ) -> str:
+            if user_id:
+                return user_id
+
+            payload = verify_launch_token(launch_token, expected_audience="report")
+            token_data = payload.get("data", {})
+            canonical_user_id = token_data.get("user_id") or payload.get("id")
+
+            if not canonical_user_id:
+                raise HTTPException(status_code=401, detail="Missing user in launch token")
+
+            return str(canonical_user_id)
+
+        @api_router.get("/form_responses/{session_id}")
+        async def get_form_responses_with_token(
+            request: Request,
+            session_id: str,
+            launchToken: str,
+            format: Optional[str] = None,
+            debug: bool = False,
+        ):
+            resolved_user_id = _resolve_report_user_id(None, launchToken)
+            return await get_form_responses(
+                request=request,
+                session_id=session_id,
+                user_id=resolved_user_id,
+                format=format,
+                debug=debug,
+            )
 
         @api_router.get("/form_responses/{session_id}/{user_id}")
         async def get_form_responses(

--- a/app/routers/form_responses.py
+++ b/app/routers/form_responses.py
@@ -1,14 +1,15 @@
-from fastapi import APIRouter, Request, HTTPException
-from fastapi.responses import RedirectResponse
+from fastapi import APIRouter, Request
 from fastapi.templating import Jinja2Templates
 from typing import Optional
 import asyncio
-from auth import verify_launch_token
 from db.form_responses_db import FormResponsesDB
 from utils.pdf_converter import convert_template_to_pdf
 from utils.llm_summary import generate_theme_summary
-
-REPORT_LAUNCH_COOKIE_MAX_AGE = 15 * 60
+from utils.report_launch import (
+    get_report_launch_token,
+    redirect_with_launch_cookie,
+    resolve_report_user_id,
+)
 
 
 class FormResponsesRouter:
@@ -24,84 +25,6 @@ class FormResponsesRouter:
     def router(self):
         api_router = APIRouter(prefix="/reports", tags=["form_responses"])
 
-        def _resolve_report_user_id(
-            user_id: Optional[str], launch_token: Optional[str]
-        ) -> str:
-            if user_id:
-                return user_id
-
-            payload = verify_launch_token(launch_token, expected_audience="report")
-            token_data = payload.get("data", {})
-            canonical_user_id = token_data.get("user_id") or payload.get("id")
-
-            if not canonical_user_id:
-                raise HTTPException(status_code=401, detail="Missing user in launch token")
-
-            return str(canonical_user_id)
-
-        def _get_launch_cookie_name(prefix: str, session_id: str) -> str:
-            safe_session_id = "".join(
-                char if char.isalnum() else "_" for char in session_id
-            )
-            return f"{prefix}_{safe_session_id}"
-
-        def _set_launch_cookie(response, request: Request, cookie_name: str, token: str, path: str):
-            response.set_cookie(
-                key=cookie_name,
-                value=token,
-                max_age=REPORT_LAUNCH_COOKIE_MAX_AGE,
-                httponly=True,
-                secure=request.url.scheme == "https",
-                samesite="lax",
-                path=path,
-            )
-
-        def _clean_query_string(request: Request) -> str:
-            params = [
-                (key, value)
-                for key, value in request.query_params.multi_items()
-                if key != "launchToken"
-            ]
-            if not params:
-                return ""
-
-            from urllib.parse import urlencode
-
-            return urlencode(params, doseq=True)
-
-        def _redirect_with_launch_cookie(
-            request: Request,
-            session_id: str,
-            launch_token: str,
-            cookie_prefix: str,
-            clean_path: str,
-        ) -> RedirectResponse:
-            verify_launch_token(launch_token, expected_audience="report")
-            redirect_url = clean_path
-            query_string = _clean_query_string(request)
-            if query_string:
-                redirect_url = f"{redirect_url}?{query_string}"
-
-            response = RedirectResponse(url=redirect_url, status_code=302)
-            cookie_name = _get_launch_cookie_name(cookie_prefix, session_id)
-            _set_launch_cookie(response, request, cookie_name, launch_token, clean_path)
-            return response
-
-        def _get_report_launch_token(
-            request: Request,
-            session_id: str,
-            launch_token: Optional[str],
-            cookie_prefix: str,
-        ) -> str:
-            if launch_token:
-                return launch_token
-
-            cookie_name = _get_launch_cookie_name(cookie_prefix, session_id)
-            token = request.cookies.get(cookie_name)
-            if not token:
-                raise HTTPException(status_code=401, detail="Missing launch token")
-            return token
-
         @api_router.get("/form_responses/{session_id}")
         async def get_form_responses_with_token(
             request: Request,
@@ -111,7 +34,7 @@ class FormResponsesRouter:
             debug: bool = False,
         ):
             if launchToken:
-                return _redirect_with_launch_cookie(
+                return redirect_with_launch_cookie(
                     request=request,
                     session_id=session_id,
                     launch_token=launchToken,
@@ -119,9 +42,9 @@ class FormResponsesRouter:
                     clean_path=f"/reports/form_responses/{session_id}",
                 )
 
-            resolved_user_id = _resolve_report_user_id(
+            resolved_user_id = resolve_report_user_id(
                 None,
-                _get_report_launch_token(
+                get_report_launch_token(
                     request=request,
                     session_id=session_id,
                     launch_token=launchToken,

--- a/app/routers/student_quiz_reports.py
+++ b/app/routers/student_quiz_reports.py
@@ -379,13 +379,6 @@ class StudentQuizReportsRouter:
                 # Use top-level student_id for report_header.student_id
                 if "report_header" in report and "student_id" in report:
                     report["report_header"]["student_id"] = report["student_id"]
-                if "test_id" in report:
-                    review_quiz_link = _build_quiz_review_link(
-                        request=request,
-                        quiz_id=report["test_id"],
-                    )
-                    if review_quiz_link:
-                        report["review_quiz_link"] = review_quiz_link
 
                 use_print = (
                     format == "pdf" or request.query_params.get("print") == "true"

--- a/app/routers/student_quiz_reports.py
+++ b/app/routers/student_quiz_reports.py
@@ -2,11 +2,12 @@ import json
 import os
 from collections import OrderedDict
 from typing import Union, Optional
-from urllib.parse import unquote
+from urllib.parse import unquote, urlencode
 
 from fastapi import APIRouter, Request
 from fastapi.templating import Jinja2Templates
 from fastapi import HTTPException, Depends
+from fastapi.responses import RedirectResponse
 from auth import verify_launch_token
 from db.reports_db import ReportsDB
 from db.bq_db import BigQueryDB
@@ -48,6 +49,7 @@ QUIZ_URL = f"{PORTAL_FRONTEND_URL}/?sessionId={{session_id}}"
 STUDENT_QUIZ_REPORT_URL = "https://reports.avantifellows.org/reports/student_quiz_report/{session_id}/{user_id}"
 
 api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
+REPORT_LAUNCH_COOKIE_MAX_AGE = 15 * 60
 
 
 class StudentQuizReportsRouter:
@@ -221,6 +223,64 @@ class StudentQuizReportsRouter:
 
             return str(canonical_user_id)
 
+        def _get_launch_cookie_name(prefix: str, session_id: str) -> str:
+            safe_session_id = "".join(
+                char if char.isalnum() else "_" for char in session_id
+            )
+            return f"{prefix}_{safe_session_id}"
+
+        def _set_launch_cookie(response, request: Request, cookie_name: str, token: str, path: str):
+            response.set_cookie(
+                key=cookie_name,
+                value=token,
+                max_age=REPORT_LAUNCH_COOKIE_MAX_AGE,
+                httponly=True,
+                secure=request.url.scheme == "https",
+                samesite="lax",
+                path=path,
+            )
+
+        def _clean_query_params(request: Request) -> str:
+            params = [
+                (key, value)
+                for key, value in request.query_params.multi_items()
+                if key != "launchToken"
+            ]
+            return urlencode(params, doseq=True)
+
+        def _redirect_with_launch_cookie(
+            request: Request,
+            session_id: str,
+            launch_token: str,
+            cookie_prefix: str,
+            clean_path: str,
+        ) -> RedirectResponse:
+            verify_launch_token(launch_token, expected_audience="report")
+            redirect_url = clean_path
+            query_string = _clean_query_params(request)
+            if query_string:
+                redirect_url = f"{redirect_url}?{query_string}"
+
+            response = RedirectResponse(url=redirect_url, status_code=302)
+            cookie_name = _get_launch_cookie_name(cookie_prefix, session_id)
+            _set_launch_cookie(response, request, cookie_name, launch_token, clean_path)
+            return response
+
+        def _get_report_launch_token(
+            request: Request,
+            session_id: str,
+            launch_token: Optional[str],
+            cookie_prefix: str,
+        ) -> str:
+            if launch_token:
+                return launch_token
+
+            cookie_name = _get_launch_cookie_name(cookie_prefix, session_id)
+            token = request.cookies.get(cookie_name)
+            if not token:
+                raise HTTPException(status_code=401, detail="Missing launch token")
+            return token
+
         @api_router.get("/student_reports/{user_id}")
         def get_student_reports(
             request: Request,
@@ -295,11 +355,28 @@ class StudentQuizReportsRouter:
         def student_quiz_report_with_token(
             request: Request,
             session_id: str,
-            launchToken: str,
+            launchToken: Optional[str] = None,
             format: Optional[str] = None,
             debug: bool = False,
         ):
-            resolved_user_id = _resolve_report_user_id(None, launchToken)
+            if launchToken:
+                return _redirect_with_launch_cookie(
+                    request=request,
+                    session_id=session_id,
+                    launch_token=launchToken,
+                    cookie_prefix="student_quiz_report_launch",
+                    clean_path=f"/reports/student_quiz_report/{session_id}",
+                )
+
+            resolved_user_id = _resolve_report_user_id(
+                None,
+                _get_report_launch_token(
+                    request=request,
+                    session_id=session_id,
+                    launch_token=launchToken,
+                    cookie_prefix="student_quiz_report_launch",
+                ),
+            )
             return student_quiz_report(
                 request=request,
                 session_id=session_id,
@@ -451,11 +528,28 @@ class StudentQuizReportsRouter:
         def student_quiz_report_v3_with_token(
             request: Request,
             session_id: str,
-            launchToken: str,
+            launchToken: Optional[str] = None,
             format: Optional[str] = None,
             debug: bool = False,
         ):
-            resolved_user_id = _resolve_report_user_id(None, launchToken)
+            if launchToken:
+                return _redirect_with_launch_cookie(
+                    request=request,
+                    session_id=session_id,
+                    launch_token=launchToken,
+                    cookie_prefix="student_quiz_report_v3_launch",
+                    clean_path=f"/reports/student_quiz_report/v3/{session_id}",
+                )
+
+            resolved_user_id = _resolve_report_user_id(
+                None,
+                _get_report_launch_token(
+                    request=request,
+                    session_id=session_id,
+                    launch_token=launchToken,
+                    cookie_prefix="student_quiz_report_v3_launch",
+                ),
+            )
             return student_quiz_report_v3(
                 request=request,
                 session_id=session_id,

--- a/app/routers/student_quiz_reports.py
+++ b/app/routers/student_quiz_reports.py
@@ -1,14 +1,17 @@
+import json
+import os
+from collections import OrderedDict
+from typing import Union, Optional
+from urllib.parse import unquote
+
 from fastapi import APIRouter, Request
 from fastapi.templating import Jinja2Templates
 from fastapi import HTTPException, Depends
-from collections import OrderedDict
-from urllib.parse import unquote
-from typing import Union, Optional
+from auth import verify_launch_token
 from db.reports_db import ReportsDB
 from db.bq_db import BigQueryDB
 from fastapi.security.api_key import APIKeyHeader
 from utils.pdf_converter import convert_template_to_pdf
-import json
 
 ROW_NAMES = OrderedDict()
 ROW_NAMES = {
@@ -35,13 +38,14 @@ CHAPTER_WISE_ROW_NAMES = {
     "chapter_code": "Chapter Code",
 }
 
-QUIZ_URL = (
-    "https://quiz.avantifellows.org/quiz/{quiz_id}?userId={user_id}&apiKey={api_key}"
-)
+PORTAL_FRONTEND_URL = (
+    os.getenv("AF_PORTAL_FRONTEND_URL")
+    or os.getenv("PORTAL_FRONTEND_URL")
+    or "https://auth.avantifellows.org"
+).rstrip("/")
+QUIZ_URL = f"{PORTAL_FRONTEND_URL}/?sessionId={{session_id}}"
 # https://reports.avantifellows.org/reports/student_quiz_report/Homework_Quiz_2022-08-03_62ea813210de4e9677c8ce2d/1403899102
 STUDENT_QUIZ_REPORT_URL = "https://reports.avantifellows.org/reports/student_quiz_report/{session_id}/{user_id}"
-
-AF_API_KEY = "6qOO8UdF1EGxLgzwIbQN"
 
 api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
 
@@ -202,6 +206,21 @@ class StudentQuizReportsRouter:
 
             return "", ""  # selected chapter name, chapter link
 
+        def _resolve_report_user_id(
+            user_id: Optional[str], launch_token: Optional[str]
+        ) -> str:
+            if user_id:
+                return unquote(user_id)
+
+            payload = verify_launch_token(launch_token, expected_audience="report")
+            token_data = payload.get("data", {})
+            canonical_user_id = token_data.get("user_id") or payload.get("id")
+
+            if not canonical_user_id:
+                raise HTTPException(status_code=401, detail="Missing user in launch token")
+
+            return str(canonical_user_id)
+
         @api_router.get("/student_reports/{user_id}")
         def get_student_reports(
             request: Request,
@@ -236,47 +255,23 @@ class StudentQuizReportsRouter:
                 )
 
             print("Getting student reports for user ID: ", user_id)
+            data = self.__reports_db.get_student_reports(user_id)
+            print(data)
 
-            # Query both v1 and v2 tables
-            v1_data = self.__reports_db.get_student_reports(user_id)
-            v2_data = self.__reports_db.get_student_reports_v2(user_id)
-
-            # Track session IDs from v2 to avoid duplicates
-            v2_session_ids = {doc["session_id"] for doc in v2_data}
-
+            # Create a structured response with student reports
             student_reports = []
-
-            # Add v1 reports (skip if session exists in v2)
-            for doc in v1_data:
+            for doc in data:
                 if "overall" not in doc["user_id-section"]:
-                    continue
-                if doc["session_id"] in v2_session_ids:
                     continue
                 result = {
                     "test_name": doc["test_name"],
                     "test_session_id": doc["session_id"],
-                    "percentile": doc.get("percentile", ""),
-                    "rank": doc.get("rank", ""),
+                    "percentile": doc["percentile"] if "percentile" in doc else "",
+                    "rank": doc["rank"] if "rank" in doc else "",
                     "report_link": STUDENT_QUIZ_REPORT_URL.format(
                         session_id=doc["session_id"], user_id=user_id
                     ),
                     "start_date": doc["start_date"],
-                }
-                student_reports.append(result)
-
-            # Add v2 reports
-            for doc in v2_data:
-                header = doc.get("report_header", {})
-                overall = doc.get("overall_performance", {})
-                result = {
-                    "test_name": header.get("test_name", ""),
-                    "test_session_id": doc["session_id"],
-                    "percentile": overall.get("percentage", ""),
-                    "rank": overall.get("cms_rank", ""),
-                    "report_link": STUDENT_QUIZ_REPORT_URL.format(
-                        session_id=doc["session_id"], user_id=user_id
-                    ),
-                    "start_date": header.get("test_date", ""),
                 }
                 student_reports.append(result)
 
@@ -295,6 +290,23 @@ class StudentQuizReportsRouter:
                 return convert_template_to_pdf(template_response, debug=debug)
 
             return template_response
+
+        @api_router.get("/student_quiz_report/{session_id}")
+        def student_quiz_report_with_token(
+            request: Request,
+            session_id: str,
+            launchToken: str,
+            format: Optional[str] = None,
+            debug: bool = False,
+        ):
+            resolved_user_id = _resolve_report_user_id(None, launchToken)
+            return student_quiz_report(
+                request=request,
+                session_id=session_id,
+                user_id=resolved_user_id,
+                format=format,
+                debug=debug,
+            )
 
         @api_router.get("/student_quiz_report/{session_id}/{user_id}")
         def student_quiz_report(
@@ -408,9 +420,7 @@ class StudentQuizReportsRouter:
 
             report_data["student_id"] = user_id
             if "platform" in data[0] and data[0]["platform"] == "quizengine":
-                report_data["test_link"] = QUIZ_URL.format(
-                    quiz_id=test_id, user_id=user_id, api_key=AF_API_KEY
-                )
+                report_data["test_link"] = QUIZ_URL.format(session_id=session_id)
 
             section_reports = []
             overall_performance = {}
@@ -436,6 +446,23 @@ class StudentQuizReportsRouter:
             if format == "pdf":
                 return convert_template_to_pdf(template_response, debug=debug)
             return template_response
+
+        @api_router.get("/student_quiz_report/v3/{session_id}")
+        def student_quiz_report_v3_with_token(
+            request: Request,
+            session_id: str,
+            launchToken: str,
+            format: Optional[str] = None,
+            debug: bool = False,
+        ):
+            resolved_user_id = _resolve_report_user_id(None, launchToken)
+            return student_quiz_report_v3(
+                request=request,
+                session_id=session_id,
+                user_id=resolved_user_id,
+                format=format,
+                debug=debug,
+            )
 
         @api_router.get("/student_quiz_report/v3/{session_id}/{user_id}")
         def student_quiz_report_v3(
@@ -499,9 +526,7 @@ class StudentQuizReportsRouter:
 
             report_data["student_id"] = user_id
             if "platform" in data[0] and data[0]["platform"] == "quizengine":
-                report_data["test_link"] = QUIZ_URL.format(
-                    quiz_id=test_id, user_id=user_id, api_key=AF_API_KEY
-                )
+                report_data["test_link"] = QUIZ_URL.format(session_id=session_id)
 
             # bigquery
             student_al_data = self.__bq_db.get_student_qualification_data(

--- a/app/routers/student_quiz_reports.py
+++ b/app/routers/student_quiz_reports.py
@@ -1,18 +1,20 @@
-import json
-import os
 from collections import OrderedDict
 from typing import Union, Optional
-from urllib.parse import unquote, urlencode, quote
+from urllib.parse import unquote, quote
 
 from fastapi import APIRouter, Request
 from fastapi.templating import Jinja2Templates
 from fastapi import HTTPException, Depends
-from fastapi.responses import RedirectResponse
-from auth import verify_launch_token
 from db.reports_db import ReportsDB
 from db.bq_db import BigQueryDB
 from fastapi.security.api_key import APIKeyHeader
 from utils.pdf_converter import convert_template_to_pdf
+from utils.report_launch import (
+    get_report_launch_token,
+    redirect_with_launch_cookie,
+    resolve_report_user_id,
+    set_request_launch_token,
+)
 
 ROW_NAMES = OrderedDict()
 ROW_NAMES = {
@@ -39,26 +41,16 @@ CHAPTER_WISE_ROW_NAMES = {
     "chapter_code": "Chapter Code",
 }
 
-PORTAL_FRONTEND_URL = (
-    os.getenv("AF_PORTAL_FRONTEND_URL")
-    or os.getenv("PORTAL_FRONTEND_URL")
-    or "https://auth.avantifellows.org"
-).rstrip("/")
-QUIZ_FRONTEND_URL = (
-    os.getenv("AF_QUIZ_FRONTEND_URL")
-    or os.getenv("QUIZ_FRONTEND_URL")
-    or ""
-).rstrip("/")
-QUIZ_API_KEY = (
-    os.getenv("AF_QUIZ_API_KEY")
-    or os.getenv("QUIZ_API_KEY")
-    or "6qOO8UdF1EGxLgzwIbQN"
+QUIZ_REVIEW_URL = (
+    "https://quiz.avantifellows.org/quiz/{quiz_id}"
+    "?apiKey={api_key}&launchToken={launch_token}"
 )
+QUIZ_AF_API_KEY = "6qOO8UdF1EGxLgzwIbQN"
+
 # https://reports.avantifellows.org/reports/student_quiz_report/Homework_Quiz_2022-08-03_62ea813210de4e9677c8ce2d/1403899102
 STUDENT_QUIZ_REPORT_URL = "https://reports.avantifellows.org/reports/student_quiz_report/{session_id}/{user_id}"
 
 api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
-REPORT_LAUNCH_COOKIE_MAX_AGE = 15 * 60
 
 
 class StudentQuizReportsRouter:
@@ -217,95 +209,6 @@ class StudentQuizReportsRouter:
 
             return "", ""  # selected chapter name, chapter link
 
-        def _resolve_report_user_id(
-            user_id: Optional[str], launch_token: Optional[str]
-        ) -> str:
-            if user_id:
-                return unquote(user_id)
-
-            payload = verify_launch_token(launch_token, expected_audience="report")
-            token_data = payload.get("data", {})
-            canonical_user_id = token_data.get("user_id") or payload.get("id")
-
-            if not canonical_user_id:
-                raise HTTPException(status_code=401, detail="Missing user in launch token")
-
-            return str(canonical_user_id)
-
-        def _get_launch_cookie_name(prefix: str, session_id: str) -> str:
-            safe_session_id = "".join(
-                char if char.isalnum() else "_" for char in session_id
-            )
-            return f"{prefix}_{safe_session_id}"
-
-        def _set_launch_cookie(response, request: Request, cookie_name: str, token: str, path: str):
-            response.set_cookie(
-                key=cookie_name,
-                value=token,
-                max_age=REPORT_LAUNCH_COOKIE_MAX_AGE,
-                httponly=True,
-                secure=request.url.scheme == "https",
-                samesite="lax",
-                path=path,
-            )
-
-        def _clean_query_params(request: Request) -> str:
-            params = [
-                (key, value)
-                for key, value in request.query_params.multi_items()
-                if key != "launchToken"
-            ]
-            return urlencode(params, doseq=True)
-
-        def _redirect_with_launch_cookie(
-            request: Request,
-            session_id: str,
-            launch_token: str,
-            cookie_prefix: str,
-            clean_path: str,
-        ) -> RedirectResponse:
-            verify_launch_token(launch_token, expected_audience="report")
-            redirect_url = clean_path
-            query_string = _clean_query_params(request)
-            if query_string:
-                redirect_url = f"{redirect_url}?{query_string}"
-
-            response = RedirectResponse(url=redirect_url, status_code=302)
-            cookie_name = _get_launch_cookie_name(cookie_prefix, session_id)
-            _set_launch_cookie(response, request, cookie_name, launch_token, clean_path)
-            return response
-
-        def _get_report_launch_token(
-            request: Request,
-            session_id: str,
-            launch_token: Optional[str],
-            cookie_prefix: str,
-        ) -> str:
-            if launch_token:
-                return launch_token
-
-            cookie_name = _get_launch_cookie_name(cookie_prefix, session_id)
-            token = request.cookies.get(cookie_name)
-            if not token:
-                raise HTTPException(status_code=401, detail="Missing launch token")
-            return token
-
-        def _set_request_launch_token(request: Request, launch_token: Optional[str]) -> None:
-            request.state.report_launch_token = launch_token
-
-        def _resolve_quiz_frontend_url(request: Request) -> str:
-            if QUIZ_FRONTEND_URL:
-                return QUIZ_FRONTEND_URL
-
-            host = request.url.hostname or ""
-            if "staging" in host:
-                return "https://staging-quiz.avantifellows.org"
-
-            if host.startswith("localhost") or host.startswith("127.0.0.1"):
-                return "http://localhost:8081"
-
-            return "https://quiz.avantifellows.org"
-
         def _build_quiz_review_link(
             request: Request,
             quiz_id: str,
@@ -314,13 +217,12 @@ class StudentQuizReportsRouter:
             if not launch_token:
                 return None
 
-            quiz_frontend_url = _resolve_quiz_frontend_url(request)
             # Direct report -> quiz review handoff reuses the verified report token.
             # Quiz resolves canonical identity from the token and strips it from the URL after boot.
-            return (
-                f"{quiz_frontend_url}/quiz/{quote(str(quiz_id), safe='')}"
-                f"?apiKey={quote(QUIZ_API_KEY, safe='')}"
-                f"&launchToken={quote(launch_token, safe='')}"
+            return QUIZ_REVIEW_URL.format(
+                quiz_id=quote(str(quiz_id), safe=""),
+                api_key=quote(QUIZ_AF_API_KEY, safe=""),
+                launch_token=quote(launch_token, safe=""),
             )
 
         @api_router.get("/student_reports/{user_id}")
@@ -402,7 +304,7 @@ class StudentQuizReportsRouter:
             debug: bool = False,
         ):
             if launchToken:
-                return _redirect_with_launch_cookie(
+                return redirect_with_launch_cookie(
                     request=request,
                     session_id=session_id,
                     launch_token=launchToken,
@@ -410,7 +312,7 @@ class StudentQuizReportsRouter:
                     clean_path=f"/reports/student_quiz_report/{session_id}",
                 )
 
-            request_launch_token = _get_report_launch_token(
+            request_launch_token = get_report_launch_token(
                 request=request,
                 session_id=session_id,
                 launch_token=launchToken,
@@ -418,7 +320,7 @@ class StudentQuizReportsRouter:
             )
             _set_request_launch_token(request, request_launch_token)
 
-            resolved_user_id = _resolve_report_user_id(
+            resolved_user_id = resolve_report_user_id(
                 None,
                 request_launch_token,
             )
@@ -590,7 +492,7 @@ class StudentQuizReportsRouter:
             debug: bool = False,
         ):
             if launchToken:
-                return _redirect_with_launch_cookie(
+                return redirect_with_launch_cookie(
                     request=request,
                     session_id=session_id,
                     launch_token=launchToken,
@@ -598,7 +500,7 @@ class StudentQuizReportsRouter:
                     clean_path=f"/reports/student_quiz_report/v3/{session_id}",
                 )
 
-            request_launch_token = _get_report_launch_token(
+            request_launch_token = get_report_launch_token(
                 request=request,
                 session_id=session_id,
                 launch_token=launchToken,
@@ -606,7 +508,7 @@ class StudentQuizReportsRouter:
             )
             _set_request_launch_token(request, request_launch_token)
 
-            resolved_user_id = _resolve_report_user_id(
+            resolved_user_id = resolve_report_user_id(
                 None,
                 request_launch_token,
             )

--- a/app/routers/student_quiz_reports.py
+++ b/app/routers/student_quiz_reports.py
@@ -2,7 +2,7 @@ import json
 import os
 from collections import OrderedDict
 from typing import Union, Optional
-from urllib.parse import unquote, urlencode
+from urllib.parse import unquote, urlencode, quote
 
 from fastapi import APIRouter, Request
 from fastapi.templating import Jinja2Templates
@@ -44,7 +44,16 @@ PORTAL_FRONTEND_URL = (
     or os.getenv("PORTAL_FRONTEND_URL")
     or "https://auth.avantifellows.org"
 ).rstrip("/")
-QUIZ_URL = f"{PORTAL_FRONTEND_URL}/?sessionId={{session_id}}"
+QUIZ_FRONTEND_URL = (
+    os.getenv("AF_QUIZ_FRONTEND_URL")
+    or os.getenv("QUIZ_FRONTEND_URL")
+    or ""
+).rstrip("/")
+QUIZ_API_KEY = (
+    os.getenv("AF_QUIZ_API_KEY")
+    or os.getenv("QUIZ_API_KEY")
+    or "6qOO8UdF1EGxLgzwIbQN"
+)
 # https://reports.avantifellows.org/reports/student_quiz_report/Homework_Quiz_2022-08-03_62ea813210de4e9677c8ce2d/1403899102
 STUDENT_QUIZ_REPORT_URL = "https://reports.avantifellows.org/reports/student_quiz_report/{session_id}/{user_id}"
 
@@ -281,6 +290,39 @@ class StudentQuizReportsRouter:
                 raise HTTPException(status_code=401, detail="Missing launch token")
             return token
 
+        def _set_request_launch_token(request: Request, launch_token: Optional[str]) -> None:
+            request.state.report_launch_token = launch_token
+
+        def _resolve_quiz_frontend_url(request: Request) -> str:
+            if QUIZ_FRONTEND_URL:
+                return QUIZ_FRONTEND_URL
+
+            host = request.url.hostname or ""
+            if "staging" in host:
+                return "https://staging-quiz.avantifellows.org"
+
+            if host.startswith("localhost") or host.startswith("127.0.0.1"):
+                return "http://localhost:8081"
+
+            return "https://quiz.avantifellows.org"
+
+        def _build_quiz_review_link(
+            request: Request,
+            quiz_id: str,
+        ) -> Optional[str]:
+            launch_token = getattr(request.state, "report_launch_token", None)
+            if not launch_token:
+                return None
+
+            quiz_frontend_url = _resolve_quiz_frontend_url(request)
+            # Direct report -> quiz review handoff reuses the verified report token.
+            # Quiz resolves canonical identity from the token and strips it from the URL after boot.
+            return (
+                f"{quiz_frontend_url}/quiz/{quote(str(quiz_id), safe='')}"
+                f"?apiKey={quote(QUIZ_API_KEY, safe='')}"
+                f"&launchToken={quote(launch_token, safe='')}"
+            )
+
         @api_router.get("/student_reports/{user_id}")
         def get_student_reports(
             request: Request,
@@ -368,14 +410,17 @@ class StudentQuizReportsRouter:
                     clean_path=f"/reports/student_quiz_report/{session_id}",
                 )
 
+            request_launch_token = _get_report_launch_token(
+                request=request,
+                session_id=session_id,
+                launch_token=launchToken,
+                cookie_prefix="student_quiz_report_launch",
+            )
+            _set_request_launch_token(request, request_launch_token)
+
             resolved_user_id = _resolve_report_user_id(
                 None,
-                _get_report_launch_token(
-                    request=request,
-                    session_id=session_id,
-                    launch_token=launchToken,
-                    cookie_prefix="student_quiz_report_launch",
-                ),
+                request_launch_token,
             )
             return student_quiz_report(
                 request=request,
@@ -432,6 +477,13 @@ class StudentQuizReportsRouter:
                 # Use top-level student_id for report_header.student_id
                 if "report_header" in report and "student_id" in report:
                     report["report_header"]["student_id"] = report["student_id"]
+                if "test_id" in report:
+                    review_quiz_link = _build_quiz_review_link(
+                        request=request,
+                        quiz_id=report["test_id"],
+                    )
+                    if review_quiz_link:
+                        report["review_quiz_link"] = review_quiz_link
 
                 use_print = (
                     format == "pdf" or request.query_params.get("print") == "true"
@@ -497,7 +549,12 @@ class StudentQuizReportsRouter:
 
             report_data["student_id"] = user_id
             if "platform" in data[0] and data[0]["platform"] == "quizengine":
-                report_data["test_link"] = QUIZ_URL.format(session_id=session_id)
+                review_quiz_link = _build_quiz_review_link(
+                    request=request,
+                    quiz_id=test_id,
+                )
+                if review_quiz_link:
+                    report_data["test_link"] = review_quiz_link
 
             section_reports = []
             overall_performance = {}
@@ -541,14 +598,17 @@ class StudentQuizReportsRouter:
                     clean_path=f"/reports/student_quiz_report/v3/{session_id}",
                 )
 
+            request_launch_token = _get_report_launch_token(
+                request=request,
+                session_id=session_id,
+                launch_token=launchToken,
+                cookie_prefix="student_quiz_report_v3_launch",
+            )
+            _set_request_launch_token(request, request_launch_token)
+
             resolved_user_id = _resolve_report_user_id(
                 None,
-                _get_report_launch_token(
-                    request=request,
-                    session_id=session_id,
-                    launch_token=launchToken,
-                    cookie_prefix="student_quiz_report_v3_launch",
-                ),
+                request_launch_token,
             )
             return student_quiz_report_v3(
                 request=request,
@@ -620,7 +680,12 @@ class StudentQuizReportsRouter:
 
             report_data["student_id"] = user_id
             if "platform" in data[0] and data[0]["platform"] == "quizengine":
-                report_data["test_link"] = QUIZ_URL.format(session_id=session_id)
+                review_quiz_link = _build_quiz_review_link(
+                    request=request,
+                    quiz_id=test_id,
+                )
+                if review_quiz_link:
+                    report_data["test_link"] = review_quiz_link
 
             # bigquery
             student_al_data = self.__bq_db.get_student_qualification_data(

--- a/app/routers/student_quiz_reports.py
+++ b/app/routers/student_quiz_reports.py
@@ -259,23 +259,42 @@ class StudentQuizReportsRouter:
                 )
 
             print("Getting student reports for user ID: ", user_id)
-            data = self.__reports_db.get_student_reports(user_id)
-            print(data)
 
-            # Create a structured response with student reports
+            # Query both v1 and v2 tables. Prefer v2 for duplicate sessions.
+            v1_data = self.__reports_db.get_student_reports(user_id)
+            v2_data = self.__reports_db.get_student_reports_v2(user_id)
+            v2_session_ids = {doc["session_id"] for doc in v2_data}
+
             student_reports = []
-            for doc in data:
+            for doc in v1_data:
                 if "overall" not in doc["user_id-section"]:
+                    continue
+                if doc["session_id"] in v2_session_ids:
                     continue
                 result = {
                     "test_name": doc["test_name"],
                     "test_session_id": doc["session_id"],
-                    "percentile": doc["percentile"] if "percentile" in doc else "",
-                    "rank": doc["rank"] if "rank" in doc else "",
+                    "percentile": doc.get("percentile", ""),
+                    "rank": doc.get("rank", ""),
                     "report_link": STUDENT_QUIZ_REPORT_URL.format(
                         session_id=doc["session_id"], user_id=user_id
                     ),
                     "start_date": doc["start_date"],
+                }
+                student_reports.append(result)
+
+            for doc in v2_data:
+                header = doc.get("report_header", {})
+                overall = doc.get("overall_performance", {})
+                result = {
+                    "test_name": header.get("test_name", ""),
+                    "test_session_id": doc["session_id"],
+                    "percentile": overall.get("percentage", ""),
+                    "rank": overall.get("cms_rank", ""),
+                    "report_link": STUDENT_QUIZ_REPORT_URL.format(
+                        session_id=doc["session_id"], user_id=user_id
+                    ),
+                    "start_date": header.get("test_date", ""),
                 }
                 student_reports.append(result)
 
@@ -318,7 +337,7 @@ class StudentQuizReportsRouter:
                 launch_token=launchToken,
                 cookie_prefix="student_quiz_report_launch",
             )
-            _set_request_launch_token(request, request_launch_token)
+            set_request_launch_token(request, request_launch_token)
 
             resolved_user_id = resolve_report_user_id(
                 None,
@@ -499,7 +518,7 @@ class StudentQuizReportsRouter:
                 launch_token=launchToken,
                 cookie_prefix="student_quiz_report_v3_launch",
             )
-            _set_request_launch_token(request, request_launch_token)
+            set_request_launch_token(request, request_launch_token)
 
             resolved_user_id = resolve_report_user_id(
                 None,

--- a/app/templates/student_quiz_report_v2.html
+++ b/app/templates/student_quiz_report_v2.html
@@ -64,6 +64,7 @@
         </header>
 
         <div class="my-6 h-px bg-gray-300"></div>
+
         <!-- Overall Score -->
         <div class="bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-lg p-6 text-center shadow-md">
             <div class="text-lg font-medium opacity-90">Overall Score</div>

--- a/app/templates/student_quiz_report_v2.html
+++ b/app/templates/student_quiz_report_v2.html
@@ -64,20 +64,6 @@
         </header>
 
         <div class="my-6 h-px bg-gray-300"></div>
-
-        {% if report.review_quiz_link %}
-        <div class="no-print flex justify-center mb-6">
-            <a
-                href="{{ report.review_quiz_link }}"
-                target="_blank"
-                data-track-button="review_quiz"
-                class="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-5 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-gray-800"
-            >
-                Click here to review your answers
-            </a>
-        </div>
-        {% endif %}
-
         <!-- Overall Score -->
         <div class="bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-lg p-6 text-center shadow-md">
             <div class="text-lg font-medium opacity-90">Overall Score</div>

--- a/app/templates/student_quiz_report_v2.html
+++ b/app/templates/student_quiz_report_v2.html
@@ -65,6 +65,19 @@
 
         <div class="my-6 h-px bg-gray-300"></div>
 
+        {% if report.review_quiz_link %}
+        <div class="no-print flex justify-center mb-6">
+            <a
+                href="{{ report.review_quiz_link }}"
+                target="_blank"
+                data-track-button="review_quiz"
+                class="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-5 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-gray-800"
+            >
+                Click here to review your answers
+            </a>
+        </div>
+        {% endif %}
+
         <!-- Overall Score -->
         <div class="bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-lg p-6 text-center shadow-md">
             <div class="text-lg font-medium opacity-90">Overall Score</div>

--- a/app/utils/report_launch.py
+++ b/app/utils/report_launch.py
@@ -1,0 +1,95 @@
+from typing import Optional
+from urllib.parse import urlencode
+
+from fastapi import HTTPException, Request
+from fastapi.responses import RedirectResponse
+
+from auth import verify_launch_token
+
+REPORT_LAUNCH_COOKIE_MAX_AGE = 15 * 60
+
+
+def resolve_report_user_id(user_id: Optional[str], launch_token: Optional[str]) -> str:
+    if user_id:
+        return user_id
+
+    payload = verify_launch_token(launch_token, expected_audience="report")
+    token_data = payload.get("data", {})
+    canonical_user_id = token_data.get("user_id") or payload.get("id")
+
+    if not canonical_user_id:
+        raise HTTPException(status_code=401, detail="Missing user in launch token")
+
+    return str(canonical_user_id)
+
+
+def get_launch_cookie_name(prefix: str, session_id: str) -> str:
+    safe_session_id = "".join(char if char.isalnum() else "_" for char in session_id)
+    return f"{prefix}_{safe_session_id}"
+
+
+def set_launch_cookie(
+    response: RedirectResponse,
+    request: Request,
+    cookie_name: str,
+    token: str,
+    path: str,
+) -> None:
+    response.set_cookie(
+        key=cookie_name,
+        value=token,
+        max_age=REPORT_LAUNCH_COOKIE_MAX_AGE,
+        httponly=True,
+        secure=request.url.scheme == "https",
+        samesite="lax",
+        path=path,
+    )
+
+
+def clean_query_string(request: Request) -> str:
+    params = [
+        (key, value)
+        for key, value in request.query_params.multi_items()
+        if key != "launchToken"
+    ]
+    return urlencode(params, doseq=True)
+
+
+def redirect_with_launch_cookie(
+    request: Request,
+    session_id: str,
+    launch_token: str,
+    cookie_prefix: str,
+    clean_path: str,
+) -> RedirectResponse:
+    verify_launch_token(launch_token, expected_audience="report")
+
+    redirect_url = clean_path
+    query_string = clean_query_string(request)
+    if query_string:
+        redirect_url = f"{redirect_url}?{query_string}"
+
+    response = RedirectResponse(url=redirect_url, status_code=302)
+    cookie_name = get_launch_cookie_name(cookie_prefix, session_id)
+    set_launch_cookie(response, request, cookie_name, launch_token, clean_path)
+    return response
+
+
+def get_report_launch_token(
+    request: Request,
+    session_id: str,
+    launch_token: Optional[str],
+    cookie_prefix: str,
+) -> str:
+    if launch_token:
+        return launch_token
+
+    cookie_name = get_launch_cookie_name(cookie_prefix, session_id)
+    token = request.cookies.get(cookie_name)
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing launch token")
+    return token
+
+
+def set_request_launch_token(request: Request, launch_token: Optional[str]) -> None:
+    request.state.report_launch_token = launch_token


### PR DESCRIPTION
## Summary
This updates reporting so portal can open quiz reports and form-response reports without putting raw `user_id` in the visible entry URL path.

## What changed
- Add launch-token entry route for standard student quiz reports.
- Add launch-token entry route for v3 student quiz reports.
- Add launch-token entry route for form-response reports.
- Verify launch tokens against portal backend before resolving the canonical `user_id`.
- Keep existing report rendering logic underneath these entry routes.
- Wire report-to-quiz review links through launch tokens instead of raw `userId` URLs.
- Restore `/reports/student_reports/{user_id}` to query both v1 and v2 report tables and prefer v2 for duplicate sessions.

## Current status
- Branch refreshed with latest `origin/main` on 2026-04-29.
- Fixed two launch-route breakages found during refresh:
  - undefined `set_request_launch_token` call path in student quiz report routes
  - missing `HTTPException` import in form-response routes

## Why
Quiz has already moved away from raw real-user `userId` URLs. Reporting needs the same auth-entry model so portal can hand off report access safely, while the existing Gurukul reports list still needs the v2-first list behavior that landed on `main`.

## Important scope note
This PR is about report entry/auth flow and report-list compatibility. It is not the full reporting data migration.

Still not fully solved here:
- Gurukul report-link cleanup end to end
- broader `v1` / standard route / `v3` rationalization
- full DynamoDB migration validation

## Assumptions
- Portal is the source of auth and mints short-lived launch tokens for reporting.
- Standard report routes remain the rendering layer after the reporting entry route resolves the canonical user.
- v2 reports should be preferred over v1 reports for duplicate sessions in the report list.

## Major files to review
- `app/auth/__init__.py`
- `app/routers/student_quiz_reports.py`
- `app/routers/form_responses.py`
- `app/utils/report_launch.py`

## Validation
- `uv run python -m compileall app`
