### PR TITLE
Make portal backend URL configurable

### DIFF
--- a/.github/workflows/deploy_to_prod.yml
+++ b/.github/workflows/deploy_to_prod.yml
@@ -67,6 +67,7 @@ jobs:
           BQ_CREDENTIALS_SECRET_NAME: ${{ secrets.BQ_CREDENTIALS_SECRET_NAME }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           HTML_TO_PDF_SERVER_URL: ${{ secrets.HTML_TO_PDF_SERVER_URL }}
+          PORTAL_BACKEND_URL: ${{ secrets.PORTAL_BACKEND_URL }}
         run: >
           sam deploy
           --stack-name ReportingProduction
@@ -86,3 +87,4 @@ jobs:
           BqCredentialsSecretName=$BQ_CREDENTIALS_SECRET_NAME
           OpenrouterApiKey=$OPENROUTER_API_KEY
           HtmlToPdfUrl=$HTML_TO_PDF_SERVER_URL
+          PortalBackendUrl=$PORTAL_BACKEND_URL

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -69,6 +69,7 @@ jobs:
           BQ_CREDENTIALS_SECRET_NAME: ${{ secrets.BQ_CREDENTIALS_SECRET_NAME }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           HTML_TO_PDF_SERVER_URL: ${{ secrets.HTML_TO_PDF_SERVER_URL }}
+          PORTAL_BACKEND_URL: ${{ secrets.PORTAL_BACKEND_URL }}
         run: >
            sam deploy
            --stack-name ReportingStaging
@@ -88,3 +89,4 @@ jobs:
            BqCredentialsSecretName=$BQ_CREDENTIALS_SECRET_NAME
            OpenrouterApiKey=$OPENROUTER_API_KEY
            HtmlToPdfUrl=$HTML_TO_PDF_SERVER_URL
+           PortalBackendUrl=$PORTAL_BACKEND_URL

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,7 +1,9 @@
+import os
+
 import httpx
 from fastapi import Request, HTTPException, status
 
-PORTAL_BACKEND_BASE_URL = "https://b93ddkdz0g.execute-api.ap-south-1.amazonaws.com"
+PORTAL_BACKEND_BASE_URL = os.environ["PORTAL_BACKEND_URL"].rstrip("/")
 VERIFICATION_URL = f"{PORTAL_BACKEND_BASE_URL}/auth/verify"
 
 

--- a/templates/prod.yaml
+++ b/templates/prod.yaml
@@ -33,6 +33,9 @@ Parameters:
   OpenrouterApiKey:
     Type: String
     Description: OpenRouter API key for AI features
+  PortalBackendUrl:
+    Type: String
+    Description: Portal backend URL for token verification
 
 Resources:
   Function:
@@ -56,6 +59,7 @@ Resources:
           DYNAMODB_STUDENT_REPORTS_TABLE_NAME: !Ref DynamodbStudentReportsTableName
           OPENROUTER_API_KEY: !Ref OpenrouterApiKey
           HTML_TO_PDF_SERVER_URL: !Ref HtmlToPdfUrl
+          PORTAL_BACKEND_URL: !Ref PortalBackendUrl
       Policies:
         - Statement:
             - Effect: Allow

--- a/templates/staging.yaml
+++ b/templates/staging.yaml
@@ -33,6 +33,9 @@ Parameters:
   OpenrouterApiKey:
     Type: String
     Description: OpenRouter API key for AI features
+  PortalBackendUrl:
+    Type: String
+    Description: Portal backend URL for token verification
 
 Resources:
   Function:
@@ -56,6 +59,7 @@ Resources:
           DYNAMODB_STUDENT_REPORTS_TABLE_NAME: !Ref DynamodbStudentReportsTableName
           OPENROUTER_API_KEY: !Ref OpenrouterApiKey
           HTML_TO_PDF_SERVER_URL: !Ref HtmlToPdfUrl
+          PORTAL_BACKEND_URL: !Ref PortalBackendUrl
       Policies:
         - Statement:
             - Effect: Allow


### PR DESCRIPTION
## Summary
- read reporting auth verification backend from mandatory PORTAL_BACKEND_URL
- pass PortalBackendUrl through SAM prod/staging templates
- wire deploy workflows to forward the GitHub secret into Lambda env

## Required secrets
- Production: PORTAL_BACKEND_URL should point to production portal-backend
- Staging: PORTAL_BACKEND_URL should point to staging portal-backend

## Verification
- parsed app/auth/__init__.py with Python AST
- checked prod/staging templates contain PORTAL_BACKEND_URL wiring