### PR TITLE
Fix 500 on student_quiz_report_v2 when a subject is fully skipped

### DIFF
--- a/app/routers/student_quiz_reports.py
+++ b/app/routers/student_quiz_reports.py
@@ -1,3 +1,4 @@
+import json
 from collections import OrderedDict
 from typing import Union, Optional
 from urllib.parse import unquote, quote
@@ -398,6 +399,20 @@ class StudentQuizReportsRouter:
                 # Use top-level student_id for report_header.student_id
                 if "report_header" in report and "student_id" in report:
                     report["report_header"]["student_id"] = report["student_id"]
+
+                # Upstream stores accuracy as DynamoDB NULL when a subject is fully skipped (0/0 undefined); templates `%.Nf|format` would crash on None.
+                _NUMERIC_FIELDS = ("percentage", "accuracy")
+                if isinstance(report.get("overall_performance"), dict):
+                    for f in _NUMERIC_FIELDS:
+                        if report["overall_performance"].get(f) is None:
+                            report["overall_performance"][f] = 0
+                if isinstance(report.get("subject_performance"), list):
+                    for subject in report["subject_performance"]:
+                        if not isinstance(subject, dict):
+                            continue
+                        for f in _NUMERIC_FIELDS:
+                            if subject.get(f) is None:
+                                subject[f] = 0
 
                 use_print = (
                     format == "pdf" or request.query_params.get("print") == "true"

--- a/app/templates/student_quiz_report_v2.html
+++ b/app/templates/student_quiz_report_v2.html
@@ -69,7 +69,7 @@
         <div class="bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-lg p-6 text-center shadow-md">
             <div class="text-lg font-medium opacity-90">Overall Score</div>
             <div class="text-4xl font-bold mt-2">{{ report.overall_performance.marks_scored|int }} / {{ report.overall_performance.max_marks_possible|int }}</div>
-            <div class="text-sm mt-2 opacity-80">{{ "%.1f"|format(report.overall_performance.percentage) }}% Score</div>
+            <div class="text-sm mt-2 opacity-80">{{ "%.1f"|format(report.overall_performance.percentage or 0) }}% Score</div>
         </div>
 
         <!-- Recommendation -->
@@ -121,11 +121,11 @@
             <div class="mt-4 grid grid-cols-2 gap-2 sm:gap-4">
                 <div class="bg-blue-50 border border-blue-200 rounded-lg p-3 sm:p-4 flex justify-between items-center">
                     <span class="text-gray-700 font-medium text-sm sm:text-base">Percentage</span>
-                    <span class="text-xl sm:text-2xl font-bold text-blue-600">{{ "%.1f"|format(report.overall_performance.percentage) }}%</span>
+                    <span class="text-xl sm:text-2xl font-bold text-blue-600">{{ "%.1f"|format(report.overall_performance.percentage or 0) }}%</span>
                 </div>
                 <div class="bg-purple-50 border border-purple-200 rounded-lg p-3 sm:p-4 flex justify-between items-center">
                     <span class="text-gray-700 font-medium text-sm sm:text-base">Accuracy</span>
-                    <span class="text-xl sm:text-2xl font-bold text-purple-600">{{ "%.1f"|format(report.overall_performance.accuracy) }}%</span>
+                    <span class="text-xl sm:text-2xl font-bold text-purple-600">{{ "%.1f"|format(report.overall_performance.accuracy or 0) }}%</span>
                 </div>
             </div>
         </section>
@@ -179,11 +179,11 @@
                         <div class="pt-2 border-t border-gray-100">
                             <div class="flex justify-between text-sm">
                                 <span class="text-gray-600">Percentage</span>
-                                <span class="font-semibold text-{{ color }}-600">{{ "%.0f"|format(subject.percentage) }}%</span>
+                                <span class="font-semibold text-{{ color }}-600">{{ "%.0f"|format(subject.percentage or 0) }}%</span>
                             </div>
                             <div class="flex justify-between text-sm mt-1">
                                 <span class="text-gray-600">Accuracy</span>
-                                <span class="font-semibold text-{{ color }}-600">{{ "%.1f"|format(subject.accuracy) }}%</span>
+                                <span class="font-semibold text-{{ color }}-600">{{ "%.1f"|format(subject.accuracy or 0) }}%</span>
                             </div>
                         </div>
                     </div>

--- a/app/templates/student_quiz_report_v2_print.html
+++ b/app/templates/student_quiz_report_v2_print.html
@@ -494,13 +494,13 @@
                             <td class="font-medium">Percentage</td>
                             <td>
                                 {{
-                                "%.2f"|format(report.overall_performance.percentage)
+                                "%.2f"|format(report.overall_performance.percentage or 0)
                                 }}%
                             </td>
                             <td class="font-medium">Accuracy</td>
                             <td>
                                 {{
-                                "%.2f"|format(report.overall_performance.accuracy)
+                                "%.2f"|format(report.overall_performance.accuracy or 0)
                                 }}%
                             </td>
                         </tr>
@@ -558,13 +558,13 @@
                         <div class="subject-card-line">
                             <span class="subject-card-label">Percentage</span>
                             <span class="subject-card-value"
-                                >{{ "%.0f"|format(subject.percentage) }}%</span
+                                >{{ "%.0f"|format(subject.percentage or 0) }}%</span
                             >
                         </div>
                         <div class="subject-card-line">
                             <span class="subject-card-label">Accuracy</span>
                             <span class="subject-card-value"
-                                >{{ "%.2f"|format(subject.accuracy) }}%</span
+                                >{{ "%.2f"|format(subject.accuracy or 0) }}%</span
                             >
                         </div>
                     </div>


### PR DESCRIPTION
## Summary

Production hit a 500 on `https://reports.avantifellows.org/reports/student_quiz_report/PunjabStudents_69d5060a9be5a82f7e85209e/204716`. CloudWatch trace:

```
File "templates/student_quiz_report_v2.html", line 186
    <span class="font-semibold text-{{ color }}-600">{{ "%.1f"|format(subject.accuracy) }}%</span>
TypeError: must be real number, not NoneType
```

The DynamoDB item for that student has `subject_performance[1].accuracy = NULL` for Maths — the student skipped all 25 questions, so `accuracy = correct / (correct + wrong) = 0/0` is mathematically undefined and the upstream pipeline persists it as DynamoDB NULL rather than 0. Jinja's `"%.Nf"|format(...)` then explodes.

## Fix (two layers)

- **`render_v2_report()` in `app/routers/student_quiz_reports.py`**: coerce `None → 0` for `percentage` and `accuracy` on both `overall_performance` and each entry of `subject_performance` before passing the payload to the template. This is the primary fix — any consumer of the v2 payload now sees clean numerics.
- **`student_quiz_report_v2.html` and `student_quiz_report_v2_print.html`**: every `"%.Nf"|format(report.overall_performance.{percentage,accuracy})` and `"%.Nf"|format(subject.{percentage,accuracy})` call now reads `... or 0` as a defense-in-depth fallback. The template can't crash on these fields even if a future code path skips the renderer sanitization.

Scope note: only the v2 + v2_print templates have `"%.Nf"|format(...)` on these fields, so those are the only files that can crash this way. The v1 (`student_quiz_report.html`) and v3 (`student_quiz_report_v3.html`) templates render the same values without `format(...)` and so cannot 500 on None.

## Drive-by

`app/routers/student_quiz_reports.py` line 656 uses `json.load(...)` but `json` was never imported (introduced March 2025) — flake8 caught it when committing this change. Added `import json` at the top. Latent `NameError` on the v3 codepath if that line is ever hit.

## Follow-up (separate ticket worth filing)

The v2 producer / ETL should emit `0.0` (or an explicit `not_attempted: true` flag) instead of DynamoDB NULL for `accuracy` when no questions were attempted. Existing rows with `accuracy: NULL` would also benefit from a one-shot backfill. I scoped this PR to a hotfix so the page stops 500-ing today; the data-quality cleanup is its own piece of work.

## Test plan

- [ ] Local: hit the v2 template with a constructed report where `subject_performance[*].accuracy = None` and confirm it renders `0.0%` instead of 500-ing.
- [ ] After deploy to staging: open the live URL `/reports/student_quiz_report/PunjabStudents_69d5060a9be5a82f7e85209e/204716` and confirm the page renders. Maths row should show `0.0%` accuracy.
- [ ] Open a known-good report (any student with all subjects attempted) and confirm the numbers are unchanged.
- [ ] PDF path: hit the same URL with `?format=pdf` and confirm the print template also renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)